### PR TITLE
Expose Set<Integer> signature in LSHMinHash

### DIFF
--- a/src/main/java/info/debatty/java/lsh/LSHMinHash.java
+++ b/src/main/java/info/debatty/java/lsh/LSHMinHash.java
@@ -24,6 +24,8 @@
 
 package info.debatty.java.lsh;
 
+import java.util.Set;
+
 /**
  *
  * @author Thibault Debatty
@@ -72,6 +74,10 @@ public class LSHMinHash extends LSH {
     
     public int[] hash(boolean[] vector) {
         return hashSignature(this.mh.signature(vector));
+    }
+
+    public int[] hash(Set<Integer> set) {
+        return hashSignature(this.mh.signature(set));
     }
     
     public int[][] getCoefficients() {


### PR DESCRIPTION
MinHash allows for Set<Integer> sparse matrix representation. This change exposes that interface through LSHMinHash as well. I needed this for my prototype, so thought you might be interested in this albeit simple change.
