### PR TITLE
add alternate constructors that take in random number generator seeds

### DIFF
--- a/src/main/java/info/debatty/java/lsh/LSHMinHash.java
+++ b/src/main/java/info/debatty/java/lsh/LSHMinHash.java
@@ -46,7 +46,29 @@ public class LSHMinHash extends LSH {
      */
     public LSHMinHash(final int s, final int b, final int n) {
         super(s, b);
-
+        this.mh = buildMinHash(s, n, null);
+    }
+    
+    /**
+     * Instantiates a LSH instance that internally uses MinHash,
+     * with s stages (or bands) and b buckets (per stage), for sets out of a
+     * dictionary of n elements.
+     *
+     * Attention: the number of buckets should be chosen such that we have at
+     * least 100 items per bucket.
+     *
+     * @param s stages
+     * @param b buckets (per stage)
+     * @param n dictionary size
+     * @param seed random number generator seed. using the same value will 
+     * guarantee identical hashes across object instantiations
+     */
+    public LSHMinHash(final int s, final int b, final int n, final long seed) {
+        super(s, b);
+        this.mh = buildMinHash(s, n, seed);
+    }
+    
+    private MinHash buildMinHash(final int s, final int n, Long seed) {
         /**
          * "Mining of Massive Datasets", p.88.
          * It can be shown that, using MinHash, the probability that the
@@ -67,7 +89,7 @@ public class LSHMinHash extends LSH {
          */
         int r = (int) Math.ceil(Math.log(1.0 / s) / Math.log(THRESHOLD)) + 1;
         int signature_size = r * s;
-        this.mh = new MinHash(signature_size, n);
+        return seed != null ? new MinHash(signature_size, n, seed) : new MinHash(signature_size, n);
     }
 
     /**

--- a/src/main/java/info/debatty/java/lsh/MinHash.java
+++ b/src/main/java/info/debatty/java/lsh/MinHash.java
@@ -119,7 +119,7 @@ public class MinHash implements Serializable {
      * @param dict_size
      */
     public MinHash(final int size, final int dict_size) {
-        init(size, dict_size);
+        init(size, dict_size, new Random());
     }
 
     /**
@@ -131,7 +131,33 @@ public class MinHash implements Serializable {
      * @param dict_size
      */
     public MinHash(final double error, final int dict_size) {
-        init(size(error), dict_size);
+        init(size(error), dict_size, new Random());
+    }
+    
+    /**
+     * Initializes hash functions to compute MinHash signatures for sets built
+     * from a dictionary of dict_size elements.
+     *
+     * @param size the number of hash functions (and the size of resulting
+     * signatures)
+     * @param dict_size
+     * @param seed random number generator seed. using the same value will 
+     * guarantee identical hashes across object instantiations
+     */
+    public MinHash(final int size, final int dict_size, final long seed) {
+        init(size, dict_size, new Random(seed));
+    }
+    
+    /**
+     * Initializes hash function to compute MinHash signatures for sets built
+     * from a dictionary of dict_size elements, with a given similarity
+     * estimation error.
+     *
+     * @param error
+     * @param dict_size
+     */
+    public MinHash(final double error, final int dict_size, final long seed) {
+        init(size(error), dict_size, new Random(seed));
     }
 
     /**
@@ -230,7 +256,7 @@ public class MinHash implements Serializable {
      * @param size
      * @param dict_size
      */
-    private void init(final int size, final int dict_size) {
+    private void init(final int size, final int dict_size, Random r) {
         if (size <= 0) {
             throw new InvalidParameterException(
                     "Signature size should be positive");
@@ -255,7 +281,6 @@ public class MinHash implements Serializable {
 
         // h = (a * x) + b
         // a and b should be randomly generated
-        Random r = new Random();
         hash_coefs = new long[n][2];
         for (int i = 0; i < n; i++) {
             hash_coefs[i][0] = r.nextInt(dict_size); // a

--- a/src/main/java/info/debatty/java/lsh/SuperBit.java
+++ b/src/main/java/info/debatty/java/lsh/SuperBit.java
@@ -62,6 +62,24 @@ public class SuperBit implements Serializable {
      * @param l number of Super-Bit [1 ..
      */
     public SuperBit(final int d, final int n, final int l) {
+        this(d, n, l, new Random());
+    }
+
+    /**
+     * Initialize SuperBit algorithm.
+     * Super-Bit depth n must be [1 .. d] and number of Super-Bit l in [1 ..
+     * The resulting code length k = n * l
+     * The K vectors are orthogonalized in L batches of N vectors
+     *
+     * @param d data space dimension
+     * @param n Super-Bit depth [1 .. d]
+     * @param l number of Super-Bit [1 ..
+     */
+    public SuperBit(final int d, final int n, final int l, long seed) {
+        this(d, n, l, new Random(seed));
+    }
+    
+    private SuperBit(final int d, final int n, final int l, Random rand) {
         if (d <= 0) {
             throw new IllegalArgumentException("Dimension d must be >= 1");
         }
@@ -87,7 +105,6 @@ public class SuperBit implements Serializable {
         int code_length = n * l;
 
         double[][] v = new double[code_length][d];
-        Random rand = new Random();
 
         for (int i = 0; i < code_length; i++) {
             double[] vector = new double[d];

--- a/src/test/java/info/debatty/java/lsh/MinHashTest.java
+++ b/src/test/java/info/debatty/java/lsh/MinHashTest.java
@@ -1,0 +1,26 @@
+package info.debatty.java.lsh;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class MinHashTest {
+
+    @Test
+    public void testSeed() {
+        MinHash mh = new MinHash(100, 100, 123456);
+        MinHash mh2 = new MinHash(100, 100, 123456);
+        
+        Random r = new Random();
+        
+        Set<Integer> ints = new HashSet<Integer>();
+        for(int i = 0; i < 50; i++)
+            ints.add(r.nextInt());
+        
+        assertArrayEquals(mh.signature(ints), mh2.signature(ints));
+    }
+}

--- a/src/test/java/info/debatty/java/lsh/SuperBitTest.java
+++ b/src/test/java/info/debatty/java/lsh/SuperBitTest.java
@@ -1,0 +1,29 @@
+package info.debatty.java.lsh;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+public class SuperBitTest {
+
+    @Test
+    public void testSeed() {
+        int d = 50;
+        SuperBit sb = new SuperBit(d, 25, 100, 123456);
+        SuperBit sb2 = new SuperBit(d, 25, 100, 123456);
+        
+        Random r = new Random();
+
+        double[] vector = new double[d];
+        for(int i = 0; i < d; i++)
+            vector[i] = r.nextDouble();
+        
+        boolean[] sig1 = sb.signature(vector);
+        boolean[] sig2 = sb2.signature(vector);
+        
+        for(int i = 0; i < sig1.length; i++)
+            assertEquals("pos " + i, sig1[i], sig2[i]);
+    }
+}


### PR DESCRIPTION
i took a shot at this. i left in the existing constructors for backward compatibility, but you may want to consider removing them so you can also remove all the serialization notes in the README.
