### PR TITLE
Hash fix

### DIFF
--- a/src/main/java/info/debatty/java/lsh/MinHash.java
+++ b/src/main/java/info/debatty/java/lsh/MinHash.java
@@ -294,7 +294,7 @@ public class MinHash implements Serializable {
     }
 
     /**
-     * Computes hi(x) as (a_i * x + b_i) % LARGE_PRIME % (Integer.MAX_VALUE+1).
+     * Computes hi(x) as (a_i * x + b_i) % LARGE_PRIME
      *
      * @param i
      * @param x

--- a/src/main/java/info/debatty/java/lsh/MinHash.java
+++ b/src/main/java/info/debatty/java/lsh/MinHash.java
@@ -28,7 +28,7 @@ import java.util.TreeSet;
  */
 public class MinHash implements Serializable {
 
-    private static final long LARGE_PRIME = 2147483659L;
+    private static final int LARGE_PRIME = 2147483647; // = 2^31 - 1 !
 
     /**
      * Compute the jaccard index between two sets.
@@ -285,11 +285,11 @@ public class MinHash implements Serializable {
         this.n = size;
 
         // h = (a * x) + b
-        // a and b should be randomly generated
+        // a and b should be randomly generated in [1,PRIME-1]
         hash_coefs = new long[n][2];
         for (int i = 0; i < n; i++) {
-            hash_coefs[i][0] = r.nextInt(Integer.MAX_VALUE) + 1; // a
-            hash_coefs[i][1] = r.nextInt(Integer.MAX_VALUE) + 1; // b
+            hash_coefs[i][0] = r.nextInt(LARGE_PRIME - 1) + 1; // a
+            hash_coefs[i][1] = r.nextInt(LARGE_PRIME - 1) + 1; // b
         }
     }
 
@@ -303,7 +303,7 @@ public class MinHash implements Serializable {
     private int h(final int i, final int x) {
         return (int)
                 ((hash_coefs[i][0] * (long) x + hash_coefs[i][1])
-                 % LARGE_PRIME % ((long) Integer.MAX_VALUE + 1));
+                 % LARGE_PRIME);
     }
 
     /**

--- a/src/main/java/info/debatty/java/lsh/MinHash.java
+++ b/src/main/java/info/debatty/java/lsh/MinHash.java
@@ -28,6 +28,8 @@ import java.util.TreeSet;
  */
 public class MinHash implements Serializable {
 
+    private static final long LARGE_PRIME = 2147483659L;
+
     /**
      * Compute the jaccard index between two sets.
      * @param s1
@@ -286,13 +288,13 @@ public class MinHash implements Serializable {
         // a and b should be randomly generated
         hash_coefs = new long[n][2];
         for (int i = 0; i < n; i++) {
-            hash_coefs[i][0] = r.nextInt(dict_size); // a
-            hash_coefs[i][1] = r.nextInt(dict_size); // b
+            hash_coefs[i][0] = r.nextInt(Integer.MAX_VALUE) + 1; // a
+            hash_coefs[i][1] = r.nextInt(Integer.MAX_VALUE) + 1; // b
         }
     }
 
     /**
-     * Computes hi(x) as (a_i * x + b_i) % dict_size.
+     * Computes hi(x) as (a_i * x + b_i) % LARGE_PRIME % (Integer.MAX_VALUE+1).
      *
      * @param i
      * @param x
@@ -300,7 +302,8 @@ public class MinHash implements Serializable {
      */
     private int h(final int i, final int x) {
         return (int)
-                ((hash_coefs[i][0] * (long) x + hash_coefs[i][1]) % dict_size);
+                ((hash_coefs[i][0] * (long) x + hash_coefs[i][1])
+                 % LARGE_PRIME % ((long) Integer.MAX_VALUE + 1));
     }
 
     /**

--- a/src/main/java/info/debatty/java/lsh/MinHash.java
+++ b/src/main/java/info/debatty/java/lsh/MinHash.java
@@ -294,7 +294,7 @@ public class MinHash implements Serializable {
     }
 
     /**
-     * Computes hi(x) as (a_i * x + b_i) % LARGE_PRIME
+     * Computes hi(x) as (a_i * x + b_i) % LARGE_PRIME .
      *
      * @param i
      * @param x


### PR DESCRIPTION
The modulus of the hash was dependent on `dict_size`. The problem with this is that `dict_size` may not be prime. When it is not prime there is a possibility that the output of the hash function will not be uniform over its range, causing an increase in the number of collisions.

I modified it so that it now uses a large, fixed prime.

I compared the old and new hash functions with different `dict_size`. For the old hash function, when `dict_size` is not a prime, the number of times a data point is considered a neighbor is very high compared to the expected theoretical value. This problem is less prominent when `dict_size` is a prime. For the new hash function, this problem occurs less often regardless of the `dict_size`.